### PR TITLE
Add linux-headers, composer version bump

### DIFF
--- a/templates/fpm-8.1/php/Dockerfile
+++ b/templates/fpm-8.1/php/Dockerfile
@@ -1,7 +1,5 @@
 ARG BASE_IMAGE
 
-FROM composer as composer
-
 FROM $BASE_IMAGE
 
 ARG USER_ID
@@ -16,7 +14,7 @@ RUN apk add npm git openjdk8-jre-base bash htop vim mc
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-RUN apk add --virtual .build-deps --no-cache --update autoconf file g++ gcc libc-dev make pkgconf re2c zlib-dev && \
+RUN apk add --virtual .build-deps --no-cache --update autoconf file g++ gcc libc-dev make pkgconf re2c zlib-dev linux-headers && \
     pecl install xdebug && \
     docker-php-ext-enable xdebug && \
     apk del .build-deps

--- a/templates/swoole-8.1/php/Dockerfile
+++ b/templates/swoole-8.1/php/Dockerfile
@@ -2,12 +2,12 @@ ARG BASE_IMAGE
 
 FROM $BASE_IMAGE
 
-RUN apk add --virtual .build-deps --no-cache --update autoconf file g++ gcc libc-dev make pkgconf re2c zlib-dev && \
+RUN apk add --virtual .build-deps --no-cache --update autoconf file g++ gcc libc-dev make pkgconf re2c zlib-dev linux-headers && \
     pecl install xdebug && \
     docker-php-ext-enable xdebug && \
     apk del .build-deps
 
-COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 RUN apk add npm git openjdk8-jre-base bash htop vim mc
 


### PR DESCRIPTION
Обновил версию composer на последнюю (2.5) в образе swoole-php8.1

Добавил linux-headers, иначе возникает ошибка при сборке:
```configure: error: rtnetlink.h is required, install the linux-headers package: apk add --update linux-headers ERROR: `/tmp/pear/temp/xdebug/configure --with-php-config=/usr/local/bin/php-config' failed```